### PR TITLE
Bugs de compilation sous linux

### DIFF
--- a/src/engine/renderparticles.cpp
+++ b/src/engine/renderparticles.cpp
@@ -1298,7 +1298,13 @@ void particle_explodesplash(const vec &o, int fade, int type, int color, int siz
     regularshape(type, 16, color, 22, num, fade, o, size, gravity, num);
 }
 
-static void regularflame(int type, const vec &p, float radius, float height, int color, int density = 3, float scale = 2.0f, float speed = 200.0f, float fade = 600.0f, int gravity = -15)
+void regular_particle_flame(int type, const vec &p, float radius, float height, int color, int density, float scale, float speed, float fade, int gravity)
+{
+    if(!canaddparticles()) return;
+    regularflame(type, p, radius, height, color, density, scale, speed, fade, gravity);
+}
+
+static void regularflame(int type, const vec &p, float radius, float height, int color, int density, float scale, float speed, float fade, int gravity)
 {
     if(!canemitparticles()) return;
 
@@ -1311,12 +1317,6 @@ static void regularflame(int type, const vec &p, float radius, float height, int
         s.y += rndscale(radius*2.0f)-radius;
         newparticle(s, v, rnd(max(int(fade*height), 1))+1, type, color, size, gravity);
     }
-}
-
-void regular_particle_flame(int type, const vec &p, float radius, float height, int color, int density, float scale, float speed, float fade, int gravity)
-{
-    if(!canaddparticles()) return;
-    regularflame(type, p, radius, height, color, density, scale, speed, fade, gravity);
 }
 
 static void makeparticles(entity &e)

--- a/src/game/weapon.cpp
+++ b/src/game/weapon.cpp
@@ -152,10 +152,15 @@ namespace game
             spread/= (d->champimillis/1000);
             nozoomspread/= (d->champimillis/1000);
         }
-        if(d->aptitude==9 && d->crouching)
+        if(d->aptitude==APT_MAGICIEN && d->aptisort2)
         {
-            spread/= 2;
-            nozoomspread/= 2;
+            spread/=3;
+            nozoomspread/=3;
+        }
+        if(d->aptitude==APT_CAMPEUR && d->crouching)
+        {
+            spread/=2;
+            nozoomspread/=2;
         }
         if(d->steromillis || d->ragemillis)
         {
@@ -411,13 +416,14 @@ namespace game
         }
         if(thirdperson)
         {
-            actor->steromillis > 0 ? damage*=2 : damage+=0;
+            actor->steromillis > 0 ? damage*=actor->aptitude==13 ? 3 : 2 : damage+=0;
             damage = (((damage*aptitudes[actor->aptitude].apt_degats)/100)*100)/aptitudes[d->aptitude].apt_resistance;
+            if(d->aptisort3>0 && d->aptitude==APT_MAGICIEN) damage = damage/5.0f;
             damage = damage/10.0f;
 
             if(actor->aptitude==3)
             {
-                if(atk==ATK_CAC349_SHOOT || atk==ATK_CACFLEAU_SHOOT || atk==ATK_CACMARTEAU_SHOOT || atk==ATK_CACMASTER_SHOOT) particle_textcopy(d->abovehead(), tempformatstring("%.1f", damage*2.0f), PART_TEXT, 2000, 0xFF0000, actor==player1 ? 7.0f : 5.0f, -8);
+                if(atk==ATK_CAC349_SHOOT || atk==ATK_CACFLEAU_SHOOT || atk==ATK_CACMARTEAU_SHOOT || atk==ATK_CACMASTER_SHOOT) particle_textcopy(d->abovehead(), tempformatstring("%.1f", damage*3.0f), PART_TEXT, 2000, 0xFF0000, actor==player1 ? 7.0f : 5.0f, -8);
                 else particle_textcopy(d->abovehead(), tempformatstring("%.1f", damage*1.0f), PART_TEXT, 2000, damage<0 ? 0x22FF22 : actor->steromillis > 0 ? 0xFF0000: 0xFF4B19,  actor==player1 ?  7.0f : 3.0f, -8);
             }
             else if(actor->aptitude==9)
@@ -1048,6 +1054,7 @@ namespace game
         int gun = attacks[atk].gun;
         int sound = attacks[atk].sound;
         //int soundwater = attacks[atk]].soundwater;
+        if(player1->aptisort2>0 && d==player1) playsound(S_SORTMAGE2);
 
         switch(atk)
         {
@@ -1398,7 +1405,7 @@ namespace game
             switch (d->aptitude)
             {
                 case 2: kickfactor = 0; break;
-                case 3: if(d->gunselect==GUN_CAC349 || d->gunselect==GUN_CACFLEAU || d->gunselect==GUN_CACMARTEAU || d->gunselect==GUN_CACMASTER) kickfactor = d->armour > 0 ? 2.5f : 25.0f; break;
+                case 3: if(d->gunselect==GUN_CAC349 || d->gunselect==GUN_CACFLEAU || d->gunselect==GUN_CACMARTEAU || d->gunselect==GUN_CACMASTER) kickfactor = 15.0f; break;
                 default: kickfactor = 2.5f;
             }
             vec kickback = vec(dir).mul(attacks[atk].kickamount*-kickfactor);
@@ -1594,7 +1601,7 @@ namespace game
         loopv(players)
         {
             gameent *d = players[i];
-            checkattacksound(d, d==following);
+            checkattacksound(d, (long)d==following);
         }
     }
 

--- a/src/shared/cube.h
+++ b/src/shared/cube.h
@@ -38,14 +38,14 @@
 
 #ifndef STANDALONE
   #ifdef __APPLE__
-    #include "SDL2/SDL.h"
+    #include "../include/SDL.h"
     #define GL_GLEXT_LEGACY
     #define __glext_h_
-    #include <OpenGL/gl.h>
+    #include "../include/SDL_opengl.h"
     #define main SDL_main
   #else
-    #include <SDL.h>
-    #include <SDL_opengl.h>
+    #include "../include/SDL.h"
+    #include "../include/SDL_opengl.h"
   #endif
 #endif
 

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -356,7 +356,7 @@ extern void particle_icon(const vec &s, int ix, int iy, int type, int fade = 200
 extern void particle_meter(const vec &s, float val, int type, int fade = 1, int color = 0xFFFFFF, int color2 = 0xFFFFF, float size = 2.0f);
 extern void particle_flare(const vec &p, const vec &dest, int fade, int type, int color = 0xFFFFFF, float size = 0.28f, physent *owner = NULL);
 extern void particle_fireball(const vec &dest, float max, int type, int fade = -1, int color = 0xFFFFFF, float size = 4.0f);
-extern void regularflame(int type, const vec &p, float radius, float height, int color, int density, float scale, float speed, float fade, int gravity);
+static void regularflame(int type, const vec &p, float radius, float height, int color, int density = 3, float scale = 2.0f, float speed = 200.0f, float fade = 600.0f, int gravity = -15);
 extern void removetrackedparticles(physent *owner = NULL);
 
 // stain
@@ -395,8 +395,8 @@ extern vec collidewall;
 extern int collideinside;
 extern physent *collideplayer;
 
-extern void moveplayer(physent *pl, int moveres, bool local, int epomillis, int jointmillis, int vitesse);
-extern bool moveplayer(physent *pl, int moveres, bool local, int curtime, int epomillis, int jointmillis, int vitesse);
+extern void moveplayer(physent *pl, int moveres, bool local, int epomillis, int jointmillis, int aptitude, int sortflash);
+extern bool moveplayer(physent *pl, int moveres, bool local, int curtime, int epomillis, int jointmillis, int aptitude, int sortflash);
 extern void crouchplayer(physent *pl, int moveres, bool local);
 extern bool collide(physent *d, const vec &dir = vec(0, 0, 0), float cutoff = 0.0f, bool playercol = true, bool insideplayercol = false);
 extern bool bounce(physent *d, float secs, float elasticity, float waterfric, float grav);


### PR DESCRIPTION
Il y a beacoup de bugs de compilation sous linux, en voilà quelques-uns en moins, à commencer par aller chercher la SDL dans les fichiers du jeu et pas chez le client, définir les valeurs par défaut de la fonction regularflame DANS SON PROTOTYPE, et pas dans sa définition ... Ah oui aussi il faut éviter de comparer un pointeur à un int (apparemment c'est interdit).
Donc voilà, mais n'empêche qu'à la fin ça compile toujours pas, voir [mon "issue"](https://github.com/CubeConflict/Cube-Conflict/issues/5) à ce sujet